### PR TITLE
fix: post EXPORT_PDF_DONE only after download callback fires [superseded]

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -76,10 +76,17 @@ window.addEventListener('message', (event) => {
   if (type !== 'EXPORT_PDF' || !filename || !markdown) return;
 
   const docDef = markdownToDocDef(filename, markdown);
-  pdfMake.createPdf(docDef).download(filename.replace(/\.md$/, '.pdf'));
+  const pdfName = filename.replace(/\.md$/, '.pdf');
+  const source = event.source;
+  const origin = event.origin;
 
-  event.source?.postMessage(
-    { type: 'EXPORT_PDF_DONE' },
-    { targetOrigin: event.origin }
-  );
+  // Wait for pdfmake's download callback before notifying the parent —
+  // posting EXPORT_PDF_DONE synchronously would let the parent remove the
+  // iframe before the blob URL is fully generated, aborting the download.
+  pdfMake.createPdf(docDef).download(pdfName, () => {
+    source?.postMessage(
+      { type: 'EXPORT_PDF_DONE' },
+      { targetOrigin: origin },
+    );
+  });
 });


### PR DESCRIPTION
## Problem

`pdfMake.createPdf().download()` is asynchronous — it generates the PDF blob in the background. The previous code posted `EXPORT_PDF_DONE` on the very next line, synchronously:

```ts
// before
pdfMake.createPdf(docDef).download(filename);
event.source?.postMessage({ type: 'EXPORT_PDF_DONE' }, ...);
```

This meant the parent app (`gist-writer`) received `EXPORT_PDF_DONE`, removed the iframe, and re-enabled the Download PDF button *before* the blob URL was fully generated. On slow devices or large documents the iframe could be torn down mid-generation, aborting the download silently.

## Fix

Move the `postMessage` inside the `download()` completion callback, which pdfmake calls once the blob is ready and the browser download has been triggered:

```ts
// after
pdfMake.createPdf(docDef).download(pdfName, () => {
  source?.postMessage({ type: 'EXPORT_PDF_DONE' }, { targetOrigin: origin });
});
```

`event.source` and `event.origin` are captured before the async call so they're available inside the callback.